### PR TITLE
Unify help text for --bundle-version

### DIFF
--- a/pkg/cmd/install/hubaddon/cmd.go
+++ b/pkg/cmd/install/hubaddon/cmd.go
@@ -50,7 +50,8 @@ func NewCmd(clusteradmFlags *genericclioptionsclusteradm.ClusteradmFlags, stream
 	cmd.Flags().StringVar(&o.names, "names", "", "Names of the built-in add-on to install (comma separated). The built-in add-ons are: application-manager, governance-policy-framework")
 	cmd.Flags().StringVar(&o.values.Namespace, "namespace", "open-cluster-management", "Namespace of the built-in add-on to install. Defaults to open-cluster-management")
 	cmd.Flags().StringVar(&o.outputFile, "output-file", "", "The generated resources will be copied in the specified file")
-	cmd.Flags().StringVar(&o.bundleVersion, "bundle-version", "default", "The image version tag to use when deploying the hub add-on")
+	cmd.Flags().StringVar(&o.bundleVersion, "bundle-version", "default",
+		"The image version tag to use when deploying the hub add-on(s). e.g. v0.6.0, defaulted to the latest release version. also, we can set \"latest\" to install latest develop version")
 
 	return cmd
 }


### PR DESCRIPTION
Both `clusteradm init` and `clusteradm install hub-addon` supports the `--bundle-version` option with the same semantics. Unify the help text to make this clear.

Example run with this change:

    $ clusteradm init -h | grep bundle-version=
      --bundle-version='default': the version of predefined compatible
      image versions. e.g. v0.6.0, defaulted to the latest release
      version. also, we can set "latest" to install latest develop
      version
    $ clusteradm install hub-addon -h | grep bundle-version=
      --bundle-version='default': The image version tag to use when
      deploying the hub add-on(s). e.g. v0.6.0, defaulted to the latest
      release version. also, we can set "latest" to install latest
      develop version

Signed-off-by: Nir Soffer <nsoffer@redhat.com>